### PR TITLE
Fix relative imports in product evaluator

### DIFF
--- a/src/product_evaluator.py
+++ b/src/product_evaluator.py
@@ -1,8 +1,8 @@
 # src/product_evaluator.py
-from ali_scraper import get_china_products
-from amazon_scraper import count_amazon_listings, get_amazon_price_estimate
-from google_trends import get_trend_score
-from utils import normalize
+from .ali_scraper import get_china_products
+from .amazon_scraper import count_amazon_listings, get_amazon_price_estimate
+from .google_trends import get_trend_score
+from .utils import normalize
 
 
 def score_product(p):


### PR DESCRIPTION
## Summary
- fix imports in `product_evaluator.py` so it can be used as part of the `src` namespace package

## Testing
- `python3 -m py_compile main.py src/*.py`
- `python3 main.py <<'EOF'
phone
EOF` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68607bbfcb58832d8943d030f9272dd4