### PR TITLE
Add FastAPI API with product image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 dropseer/
 ├── main.py
+├── api.py
 ├── requirements.txt
 ├── src/
 │   ├── ali_scraper.py
@@ -8,3 +9,14 @@ dropseer/
 │   ├── product_evaluator.py
 │   ├── exporter.py
 │   └── utils.py
+
+## Running the API
+
+Install the dependencies and start the FastAPI server:
+
+```bash
+pip install -r requirements.txt
+uvicorn api:app --reload
+```
+
+Use `/products?keyword=your+keyword` to get the best products and `/product?keyword=your+keyword&name=Product+Name` to get details for a specific product including its image URL.

--- a/api.py
+++ b/api.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI, HTTPException
+from src.product_evaluator import find_best_products
+
+app = FastAPI()
+
+@app.get("/products")
+def read_products(keyword: str):
+    """Return a list of best products for the given keyword."""
+    products = find_best_products(keyword)
+    return {"products": products}
+
+@app.get("/product")
+def read_product(keyword: str, name: str):
+    """Return details about a specific product."""
+    products = find_best_products(keyword)
+    for p in products:
+        if p["name"].lower() == name.lower():
+            return p
+    raise HTTPException(status_code=404, detail="Product not found")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 requests
 beautifulsoup4
 pytrends
+fastapi
+uvicorn

--- a/src/ali_scraper.py
+++ b/src/ali_scraper.py
@@ -19,6 +19,7 @@ def get_china_products(keyword, max_results=5):
         name_tag = item.select_one("a._3t7zg")
         price_tag = item.select_one("div._12A8D")
         order_tag = item.select_one("span._1kNf9")
+        image_tag = item.select_one("img")
 
         if not (name_tag and price_tag):
             continue
@@ -26,12 +27,14 @@ def get_china_products(keyword, max_results=5):
         name = name_tag.text.strip()
         price = float(price_tag.text.replace('$', '').split()[0])
         orders = int(order_tag.text.split()[0].replace(',', '')) if order_tag else 0
+        image_url = image_tag["src"] if image_tag and image_tag.get("src") else ""
 
         products.append({
             "name": name,
             "china_price": price,
             "orders": orders,
-            "rating": 4.5  # Placeholder
+            "image_url": image_url,
+            "rating": 4.5,  # Placeholder
         })
 
     return products


### PR DESCRIPTION
## Summary
- scrape product image URLs from AliExpress
- add FastAPI API to serve product lists and details
- document how to run the API
- include FastAPI and uvicorn in requirements

## Testing
- `python -m py_compile main.py api.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68607ce7820c832d855582839f1f541b