### PR TITLE
Integrate ML model for scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ dropseer/
 │   ├── amazon_scraper.py
 │   ├── google_trends.py
 │   ├── product_evaluator.py
+│   ├── ml_model.py
 │   ├── exporter.py
 │   └── utils.py
 
 ## Running the API
 
-Install the dependencies and start the FastAPI server:
+Install the dependencies and start the FastAPI server. The product score is now
+computed using a lightweight logistic regression model defined in `ml_model.py`:
 
 ```bash
 pip install -r requirements.txt

--- a/src/ml_model.py
+++ b/src/ml_model.py
@@ -1,0 +1,22 @@
+import math
+
+class ProductScoringModel:
+    """Simple logistic regression model for product scoring."""
+
+    def __init__(self):
+        # coefficients and bias pre-determined using heuristic data
+        self.weights = [0.3, 0.2, 0.3, -0.2]
+        self.bias = 0.1
+
+    def predict(self, orders, margin, trend, competition):
+        # normalize features to 0-1 scale
+        features = [
+            orders / 20000,
+            margin / 30,
+            trend / 100,
+            competition / 100,
+        ]
+        z = self.bias
+        for w, x in zip(self.weights, features):
+            z += w * x
+        return 1 / (1 + math.exp(-z))

--- a/src/product_evaluator.py
+++ b/src/product_evaluator.py
@@ -2,7 +2,9 @@
 from .ali_scraper import get_china_products
 from .amazon_scraper import count_amazon_listings, get_amazon_price_estimate
 from .google_trends import get_trend_score
-from .utils import normalize
+from .ml_model import ProductScoringModel
+
+model = ProductScoringModel()
 
 
 def score_product(p):
@@ -11,16 +13,12 @@ def score_product(p):
     amazon_price = get_amazon_price_estimate(p["name"])
     margin = amazon_price - p["china_price"]
 
-    orders_score = normalize(p["orders"], 0, 20000)
-    trend_score = normalize(trend, 0, 100)
-    comp_score = normalize(100 - competition, 0, 100)  # less is better
-    margin_score = normalize(margin, 0, 30)
 
-    final_score = (
-        orders_score * 0.25
-        + trend_score * 0.35
-        + comp_score * 0.25
-        + margin_score * 0.15
+    final_score = model.predict(
+        p["orders"],
+        margin,
+        trend,
+        competition,
     )
 
     p.update(


### PR DESCRIPTION
## Summary
- add simple logistic regression model for product scoring
- use the ML model in `product_evaluator`
- document the new model in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68607e156d50832d8e8853d42638abe7