### PR TITLE
Add ML training pipeline and trend utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ dropseer/
 │   ├── ml_model.py
 │   ├── exporter.py
 │   └── utils.py
+├── train_model.py
+├── record_trend.py
+└── src/trending_tags.py
 
 ## Running the API
 
@@ -22,3 +25,33 @@ uvicorn api:app --reload
 ```
 
 Use `/products?keyword=your+keyword` to get the best products and `/product?keyword=your+keyword&name=Product+Name` to get details for a specific product including its image URL.
+
+## Training the model
+
+Provide a CSV file with columns `orders`, `margin`, `trend`, `competition` and `label` (1 if a product became a best seller, else 0). Run:
+
+```bash
+python train_model.py your_training_data.csv
+```
+
+The learned weights will be written to `trained_weights.csv`.
+
+## Recording trend data
+
+To build a time series of Google Trends data run daily:
+
+```bash
+python record_trend.py "your keyword"
+```
+
+This will append the current trend score to `trend_timeseries.csv`.
+
+## Fetching trending tags
+
+Retrieve the latest trending hashtags from TikTok:
+
+```python
+from src.trending_tags import get_tiktok_trending_hashtags
+
+print(get_tiktok_trending_hashtags())
+```

--- a/record_trend.py
+++ b/record_trend.py
@@ -1,0 +1,15 @@
+import argparse
+
+from src.trend_tracker import append_daily_trend
+
+
+def main(keyword: str):
+    append_daily_trend(keyword)
+    print("Trend data recorded")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Record daily trend score")
+    parser.add_argument("keyword", help="Keyword to track")
+    args = parser.parse_args()
+    main(args.keyword)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ beautifulsoup4
 pytrends
 fastapi
 uvicorn
+scikit-learn
+schedule

--- a/src/ml_model.py
+++ b/src/ml_model.py
@@ -1,4 +1,8 @@
 import math
+from typing import Iterable, Sequence
+
+from sklearn.linear_model import LogisticRegression
+
 
 class ProductScoringModel:
     """Simple logistic regression model for product scoring."""
@@ -7,6 +11,8 @@ class ProductScoringModel:
         # coefficients and bias pre-determined using heuristic data
         self.weights = [0.3, 0.2, 0.3, -0.2]
         self.bias = 0.1
+        
+        self._model = None
 
     def predict(self, orders, margin, trend, competition):
         # normalize features to 0-1 scale
@@ -20,3 +26,22 @@ class ProductScoringModel:
         for w, x in zip(self.weights, features):
             z += w * x
         return 1 / (1 + math.exp(-z))
+
+    def fit(self, X: Iterable[Sequence[float]], y: Iterable[int]):
+        """Train the logistic regression model using historical data."""
+        # Normalize training features similar to prediction
+        normalized = []
+        for orders, margin, trend, competition in X:
+            normalized.append([
+                orders / 20000,
+                margin / 30,
+                trend / 100,
+                competition / 100,
+            ])
+
+        clf = LogisticRegression()
+        clf.fit(normalized, list(y))
+
+        self.weights = clf.coef_[0].tolist()
+        self.bias = float(clf.intercept_[0])
+        self._model = clf

--- a/src/trend_tracker.py
+++ b/src/trend_tracker.py
@@ -1,0 +1,26 @@
+import csv
+from datetime import datetime
+
+from .google_trends import get_trend_score
+
+
+def append_daily_trend(keyword, filename="trend_timeseries.csv"):
+    """Append today's trend score for a keyword to a CSV time series."""
+    trend = get_trend_score(keyword)
+    row = {
+        "date": datetime.utcnow().strftime("%Y-%m-%d"),
+        "keyword": keyword,
+        "trend": trend,
+    }
+    write_header = False
+    try:
+        with open(filename, "r", newline="", encoding="utf-8") as f:
+            pass
+    except FileNotFoundError:
+        write_header = True
+
+    with open(filename, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=row.keys())
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)

--- a/src/trending_tags.py
+++ b/src/trending_tags.py
@@ -1,0 +1,19 @@
+import requests
+from bs4 import BeautifulSoup
+
+
+def get_tiktok_trending_hashtags(limit=10):
+    """Scrape trending hashtags from TikTok discover page."""
+    url = "https://www.tiktok.com/discover"
+    headers = {"User-Agent": "Mozilla/5.0"}
+    resp = requests.get(url, headers=headers)
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    tags = []
+    for a in soup.select("a[href^='/tag/']"):
+        tag = a.text.strip().lstrip('#')
+        if tag and tag not in tags:
+            tags.append(tag)
+        if len(tags) >= limit:
+            break
+    return tags

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.ml_model import ProductScoringModel
+
+
+def test_fit_updates_weights():
+    model = ProductScoringModel()
+    X = [
+        [1000, 10, 50, 20],
+        [2000, 20, 60, 30],
+        [3000, 15, 40, 25],
+        [4000, 25, 70, 40],
+    ]
+    y = [0, 0, 1, 1]
+    old_weights = model.weights.copy()
+    model.fit(X, y)
+    assert model.weights != old_weights

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,44 @@
+import csv
+from pathlib import Path
+
+from src.ml_model import ProductScoringModel
+
+
+def load_training_data(path: str):
+    X = []
+    y = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            X.append(
+                [
+                    float(row["orders"]),
+                    float(row["margin"]),
+                    float(row["trend"]),
+                    float(row["competition"]),
+                ]
+            )
+            y.append(int(row["label"]))
+    return X, y
+
+
+def main(data_file: str, output_file: str = "trained_weights.csv"):
+    X, y = load_training_data(data_file)
+    model = ProductScoringModel()
+    model.fit(X, y)
+
+    with open(output_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["bias"] + ["w" + str(i) for i in range(len(model.weights))])
+        writer.writerow([model.bias] + model.weights)
+    print(f"Weights saved to {output_file}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train product scoring model")
+    parser.add_argument("data", help="Path to training CSV file")
+    parser.add_argument("--out", default="trained_weights.csv", help="Output file for weights")
+    args = parser.parse_args()
+    main(args.data, args.out)


### PR DESCRIPTION
## Summary
- implement logistic regression training in `ml_model.py`
- add `train_model.py` script to train from CSV data
- add `trend_tracker` module and CLI to record Google Trend scores
- scrape trending hashtags with `trending_tags.py`
- document new features and requirements
- basic test for training

## Testing
- `pip install -r requirements.txt` *(fails: cannot access internet)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_68607f3c0e38832db04b90d308c304cd